### PR TITLE
Modified README.md file for GitPages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ All you have to do to use the wiki is clone the repo to anywhere you can open HT
 
 Contributors please see here: https://github.com/mubix/post-exploitation-wiki/wiki/Contributor-Wiki
 
+### Live Online Copy:
+
+You can find a copy of the project online at: http://mubix.github.io/post-exploitation-wiki/
+
 ### Offline Use:
 
   1. Clone the repository or pull the archive (zip) of the repo


### PR DESCRIPTION
Updated the README.md file to take into account that there we are hopefully all now copying updates across to the gh-pages which will allow people to view a live copy of the files at http://mubix.github.io/post-exploitation-wiki/ in case they don't want to install everything themselves.This way people can quickly and easily browse the changes without needing to clone the repository and might help encourage more feedback from those who might not otherwise comment.
